### PR TITLE
Fix UI displacement

### DIFF
--- a/FKHeightAdjustUI/FKHeightAdjustUI.cs
+++ b/FKHeightAdjustUI/FKHeightAdjustUI.cs
@@ -53,7 +53,7 @@ namespace FKHeightAdjustUI
             Slider sizeSlider = GameObject.Find("StudioScene/Canvas Main Menu/02_Manipulate/00_Chara/02_Kinematic/00_FK/Slider Size").GetComponent<Slider>();
             HeightAdjustSlider = GameObject.Instantiate(sizeSlider, sizeSlider.transform.parent);
             HeightAdjustSlider.name = "Slider HeightAdj";
-            HeightAdjustSlider.transform.Translate(new Vector3(-80, -60, 0), Space.Self);
+            HeightAdjustSlider.transform.localPosition = new Vector3(sizeSlider.transform.localPosition.x - 75, sizeSlider.transform.localPosition.y - 60, 0);
             HeightAdjustSlider.GetComponent<RectTransform>().sizeDelta = new Vector2(200, 20);
 
             UpdateSliderRange();


### PR DESCRIPTION
UI is displaced when game is not in standard resolution and UI scale. Here is my quick fix. Don't know if it's the best solution or not 😅

Before (1600x900. 0.85 UI scale):
![image](https://user-images.githubusercontent.com/8879012/149608903-39e10619-5f9b-468a-8c93-e83b045fbc37.png)

After (1600x900. 0.85 UI scale):
![image](https://user-images.githubusercontent.com/8879012/149608912-ee8790b6-ebde-476c-9b8f-47d9045d78d0.png)
