### PR TITLE
Fixed a bug that caused an exception when changing clothes

### DIFF
--- a/FKHeightAdjustUI/FKHeightAdjustUICharaController.cs
+++ b/FKHeightAdjustUI/FKHeightAdjustUICharaController.cs
@@ -130,7 +130,9 @@ namespace FKHeightAdjustUI
                 if (HeightAdjustModifier == null)
                     HeightAdjustModifier = new BoneModifierData();
 
-                if (!(controller.ChaControl.GetOCIChar().oiCharInfo.enableFK && controller.ChaControl.GetOCIChar().oiCharInfo.activeFK[3]))
+                var charInfo = controller?.ChaControl?.GetOCIChar()?.oiCharInfo;
+
+                if (!(charInfo != null && charInfo.enableFK && charInfo.activeFK[3]))
                     return null;
 
                 if (!HeightAdjustBones.Contains(bone))


### PR DESCRIPTION
When changing clothes in Koikatsu Sunshine, certain steps were causing an exception. This is a pull request to fix that. Please merge if there is no problem.

Reproduction procedure: 
1. launch Sunshine studio
2. Load any character
3. Open the Load Costume menu 
4. Click [Show Selection]
5. Click on Switch Costumes
![スクリーンショット 2023-12-01 221709](https://github.com/OrangeSpork/FKHeightAdjustUI/assets/4230203/c3f9a012-4f27-426c-bd6c-308224c8d9f4)

```
NullReferenceException: Object reference not set to an instance of an object
  at FKHeightAdjustUI.FKHeightAdjustUICharaController+HeightAdjustBoneEffect.GetEffect (System.String bone, KKABMX.Core.BoneController origin, ChaFileDefine+CoordinateType coordinate) [0x00029] in <9aa19bbf76674a98b3b453a0ea6f83c8>:0 
  at KKABMX.Core.BoneController.ApplyEffects () [0x00091] in <9613b052ac694d038bcfe57dbba2fd3b>:0 
  at KKABMX.Core.BoneController.LateUpdate () [0x0005c] in <9613b052ac694d038bcfe57dbba2fd3b>:0 
```
[output_log.txt](https://github.com/OrangeSpork/FKHeightAdjustUI/files/13527116/output_log.txt)

This problem does not occur in KK.
It appears to be a bug that occurs only in KKS.
There seems to be a moment when oiCharInfo is null when clicking [Show Selection] to change the outfit.



